### PR TITLE
Make GHC base libraries dependent on GHC version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ Stack2nix can generate a nix expressions for Haskell packages hosted in git repo
 ## Testing
 
 Run `./scripts/travis.sh` to build and test.
+
+## Development
+
+### Updating GHC base packages
+
+```
+curl https://raw.githubusercontent.com/bgamari/ghc-utils/master/library-versions/pkg_versions.txt > pkg_versions.txt
+```
+
+then check it into the repo.

--- a/pkg_versions.txt
+++ b/pkg_versions.txt
@@ -1,0 +1,104 @@
+# packed versions file -- generate with ./pack_pkg_list.hs
+#
+
+# We extract the Win32 pkg version information manually here
+7.0.1   Win32/2.2.0.2
+7.0.2   Win32/2.2.0.2
+7.0.3   Win32/2.2.0.2
+7.0.4   Win32/2.2.0.2
+7.2.1   Win32/2.2.1.0
+7.2.2   Win32/2.2.1.0
+7.4.1   Win32/2.2.2.0
+7.4.2   Win32/2.2.2.0
+7.6.1   Win32/2.3.0.0
+7.6.2   Win32/2.3.0.0
+7.6.3   Win32/2.3.0.0
+7.8.1	Win32/2.3.0.2
+7.8.2	Win32/2.3.0.2
+7.8.3	Win32/2.3.0.2
+7.8.4	Win32/2.3.0.2
+7.10.1	Win32/2.3.1.0
+7.10.2	Win32/2.3.1.0
+7.10.3	Win32/2.3.1.0
+8.0.1	Win32/2.3.1.1
+8.0.2	Win32/2.3.1.1
+8.2.1   Win32/2.5.4.1
+8.2.2   Win32/2.5.4.1
+8.4.1   Win32/2.6.1.0
+8.4.2   Win32/2.6.1.0
+8.4.3   Win32/2.6.1.0
+8.4.4   Win32/2.6.1.0
+8.6.1   Win32/2.6.1.0
+8.6.2   Win32/2.6.1.0
+8.6.3   Win32/2.6.1.0
+8.6.4   Win32/2.6.1.0
+8.6.5   Win32/2.6.1.0
+8.8.1   Win32/2.6.1.0
+HEAD    Win32/2.6.1.0
+
+############################################
+# GHC 7.0 - GHC 7.6
+7.0.1	Cabal/1.10.0.0 array/0.3.0.2 base/4.3.0.0 bin-package-db/0.0.0.0 bytestring/0.9.1.8 containers/0.4.0.0 directory/1.1.0.0 extensible-exceptions/0.1.1.2 ffi/1.0 filepath/1.2.0.0 ghc/7.0.1* ghc-binary/0.5.0.2* ghc-prim/0.2.0.0 haskell2010/1.0.0.0* haskell98/1.1.0.0 hpc/0.5.0.6 integer-gmp/0.2.0.2 old-locale/1.0.0.2 old-time/1.0.0.6 pretty/1.0.1.2 process/1.0.1.4 random/1.0.0.3 rts/1.0 template-haskell/2.5.0.0 time/1.2.0.3 unix/2.4.1.0
+7.0.2	Cabal/1.10.1.0 array/0.3.0.2 base/4.3.1.0 bin-package-db/0.0.0.0 bytestring/0.9.1.10 containers/0.4.0.0 directory/1.1.0.0 extensible-exceptions/0.1.1.2 ffi/1.0 filepath/1.2.0.0 ghc/7.0.2* ghc-binary/0.5.0.2* ghc-prim/0.2.0.0 haskell2010/1.0.0.0* haskell98/1.1.0.1 hpc/0.5.0.6 integer-gmp/0.2.0.3 old-locale/1.0.0.2 old-time/1.0.0.6 pretty/1.0.1.2 process/1.0.1.5 random/1.0.0.3 rts/1.0 template-haskell/2.5.0.0 time/1.2.0.3 unix/2.4.2.0
+7.0.3	Cabal/1.10.1.0 array/0.3.0.2 base/4.3.1.0 bin-package-db/0.0.0.0 bytestring/0.9.1.10 containers/0.4.0.0 directory/1.1.0.0 extensible-exceptions/0.1.1.2 ffi/1.0 filepath/1.2.0.0 ghc/7.0.3* ghc-binary/0.5.0.2* ghc-prim/0.2.0.0 haskell2010/1.0.0.0* haskell98/1.1.0.1 hpc/0.5.0.6 integer-gmp/0.2.0.3 old-locale/1.0.0.2 old-time/1.0.0.6 pretty/1.0.1.2 process/1.0.1.5 random/1.0.0.3 rts/1.0 template-haskell/2.5.0.0 time/1.2.0.3 unix/2.4.2.0
+7.0.4	Cabal/1.10.2.0 array/0.3.0.2 base/4.3.1.0 bin-package-db/0.0.0.0 bytestring/0.9.1.10 containers/0.4.0.0 directory/1.1.0.0 extensible-exceptions/0.1.1.2 ffi/1.0 filepath/1.2.0.0 ghc/7.0.4* ghc-binary/0.5.0.2* ghc-prim/0.2.0.0 haskell2010/1.0.0.0* haskell98/1.1.0.1 hpc/0.5.0.6 integer-gmp/0.2.0.3 old-locale/1.0.0.2 old-time/1.0.0.6 pretty/1.0.1.2 process/1.0.1.5 random/1.0.0.3 rts/1.0 template-haskell/2.5.0.0 time/1.2.0.3 unix/2.4.2.0
+7.2.1	Cabal/1.12.0 array/0.3.0.3 base/4.4.0.0 bin-package-db/0.0.0.0 binary/0.5.0.2* bytestring/0.9.2.0 containers/0.4.1.0 directory/1.1.0.1 extensible-exceptions/0.1.1.3 ffi/1.0 filepath/1.2.0.1 ghc/7.2.1* ghc-prim/0.2.0.0 haskell2010/1.1.0.0* haskell98/2.0.0.0* hoopl/3.8.7.1 hpc/0.5.1.0 integer-gmp/0.3.0.0 old-locale/1.0.0.3 old-time/1.0.0.7 pretty/1.1.0.0 process/1.1.0.0 rts/1.0 template-haskell/2.6.0.0 time/1.2.0.5 unix/2.5.0.0
+7.2.2	Cabal/1.12.0 array/0.3.0.3 base/4.4.1.0 bin-package-db/0.0.0.0 binary/0.5.0.2* bytestring/0.9.2.0 containers/0.4.1.0 directory/1.1.0.1 extensible-exceptions/0.1.1.3 ffi/1.0 filepath/1.2.0.1 ghc/7.2.2* ghc-prim/0.2.0.0 haskell2010/1.1.0.0* haskell98/2.0.0.0* hoopl/3.8.7.1 hpc/0.5.1.0 integer-gmp/0.3.0.0 old-locale/1.0.0.3 old-time/1.0.0.7 pretty/1.1.0.0 process/1.1.0.0 rts/1.0 template-haskell/2.6.0.0 time/1.2.0.5 unix/2.5.0.0
+7.4.1	Cabal/1.14.0 array/0.4.0.0 base/4.5.0.0 bin-package-db/0.0.0.0 binary/0.5.1.0 bytestring/0.9.2.1 containers/0.4.2.1 deepseq/1.3.0.0 directory/1.1.0.2 extensible-exceptions/0.1.1.4 filepath/1.3.0.0 ghc/7.4.1* ghc-prim/0.2.0.0 haskell2010/1.1.0.1* haskell98/2.0.0.1* hoopl/3.8.7.3 hpc/0.5.1.1 integer-gmp/0.4.0.0 old-locale/1.0.0.4 old-time/1.1.0.0 pretty/1.1.1.0 process/1.1.0.1 rts/1.0 template-haskell/2.7.0.0 time/1.4 unix/2.5.1.0
+7.4.2	Cabal/1.14.0 array/0.4.0.0 base/4.5.1.0 bin-package-db/0.0.0.0 binary/0.5.1.0 bytestring/0.9.2.1 containers/0.4.2.1 deepseq/1.3.0.0 directory/1.1.0.2 extensible-exceptions/0.1.1.4 filepath/1.3.0.0 ghc/7.4.2* ghc-prim/0.2.0.0 haskell2010/1.1.0.1* haskell98/2.0.0.1* hoopl/3.8.7.3 hpc/0.5.1.1 integer-gmp/0.4.0.0 old-locale/1.0.0.4 old-time/1.1.0.0 pretty/1.1.1.0 process/1.1.0.1 rts/1.0 template-haskell/2.7.0.0 time/1.4 unix/2.5.1.1
+7.6.1	Cabal/1.16.0 array/0.4.0.1 base/4.6.0.0 bin-package-db/0.0.0.0 binary/0.5.1.1 bytestring/0.10.0.0 containers/0.5.0.0 deepseq/1.3.0.1 directory/1.2.0.0 filepath/1.3.0.1 ghc/7.6.1* ghc-prim/0.3.0.0 haskell2010/1.1.1.0* haskell98/2.0.0.2* hoopl/3.9.0.0 hpc/0.6.0.0 integer-gmp/0.5.0.0 old-locale/1.0.0.5 old-time/1.1.0.1 pretty/1.1.1.0 process/1.1.0.2 rts/1.0 template-haskell/2.8.0.0 time/1.4.0.1 unix/2.6.0.0
+7.6.2	Cabal/1.16.0 array/0.4.0.1 base/4.6.0.1 bin-package-db/0.0.0.0 binary/0.5.1.1 bytestring/0.10.0.2 containers/0.5.0.0 deepseq/1.3.0.1 directory/1.2.0.1 filepath/1.3.0.1 ghc/7.6.2* ghc-prim/0.3.0.0 haskell2010/1.1.1.0* haskell98/2.0.0.2* hoopl/3.9.0.0 hpc/0.6.0.0 integer-gmp/0.5.0.0 old-locale/1.0.0.5 old-time/1.1.0.1 pretty/1.1.1.0 process/1.1.0.2 rts/1.0 template-haskell/2.8.0.0 time/1.4.0.1 unix/2.6.0.1
+7.6.3	Cabal/1.16.0 array/0.4.0.1 base/4.6.0.1 bin-package-db/0.0.0.0 binary/0.5.1.1 bytestring/0.10.0.2 containers/0.5.0.0 deepseq/1.3.0.1 directory/1.2.0.1 filepath/1.3.0.1 ghc/7.6.3* ghc-prim/0.3.0.0 haskell2010/1.1.1.0* haskell98/2.0.0.2* hoopl/3.9.0.0 hpc/0.6.0.0 integer-gmp/0.5.0.0 old-locale/1.0.0.5 old-time/1.1.0.1 pretty/1.1.1.0 process/1.1.0.2 rts/1.0 template-haskell/2.8.0.0 time/1.4.0.1 unix/2.6.0.1
+
+############################################
+# GHC 7.8.x
+7.8.1	Cabal/1.18.1.3 array/0.5.0.0 base/4.7.0.0 bin-package-db/0.0.0.0 binary/0.7.1.0 bytestring/0.10.4.0 containers/0.5.5.1 deepseq/1.3.0.2 directory/1.2.1.0 filepath/1.3.0.2 ghc/7.8.1* ghc-prim/0.3.1.0 haskell2010/1.1.2.0* haskell98/2.0.0.3* hoopl/3.10.0.1 hpc/0.6.0.1 integer-gmp/0.5.1.0 old-locale/1.0.0.6 old-time/1.1.0.2 pretty/1.1.1.1 process/1.2.0.0 rts/1.0 template-haskell/2.9.0.0 time/1.4.2 transformers/0.3.0.0 unix/2.7.0.1
+7.8.2	Cabal/1.18.1.3 array/0.5.0.0 base/4.7.0.0 bin-package-db/0.0.0.0 binary/0.7.1.0 bytestring/0.10.4.0 containers/0.5.5.1 deepseq/1.3.0.2 directory/1.2.1.0 filepath/1.3.0.2 ghc/7.8.2* ghc-prim/0.3.1.0 haskell2010/1.1.2.0* haskell98/2.0.0.3* hoopl/3.10.0.1 hpc/0.6.0.1 integer-gmp/0.5.1.0 old-locale/1.0.0.6 old-time/1.1.0.2 pretty/1.1.1.1 process/1.2.0.0 rts/1.0 template-haskell/2.9.0.0 time/1.4.2 transformers/0.3.0.0 unix/2.7.0.1
+7.8.3	Cabal/1.18.1.3 array/0.5.0.0 base/4.7.0.1 bin-package-db/0.0.0.0 binary/0.7.1.0 bytestring/0.10.4.0 containers/0.5.5.1 deepseq/1.3.0.2 directory/1.2.1.0 filepath/1.3.0.2 ghc/7.8.3* ghc-prim/0.3.1.0 haskeline/0.7.1.2 haskell2010/1.1.2.0* haskell98/2.0.0.3* hoopl/3.10.0.1 hpc/0.6.0.1 integer-gmp/0.5.1.0 old-locale/1.0.0.6 old-time/1.1.0.2 pretty/1.1.1.1 process/1.2.0.0 rts/1.0 template-haskell/2.9.0.0 terminfo/0.4.0.0 time/1.4.2 transformers/0.3.0.0 unix/2.7.0.1 xhtml/3000.2.1
+7.8.4	Cabal/1.18.1.5 array/0.5.0.0 base/4.7.0.2 bin-package-db/0.0.0.0 binary/0.7.1.0 bytestring/0.10.4.0 containers/0.5.5.1 deepseq/1.3.0.2 directory/1.2.1.0 filepath/1.3.0.2 ghc/7.8.4* ghc-prim/0.3.1.0 haskeline/0.7.1.2 haskell2010/1.1.2.0* haskell98/2.0.0.3* hoopl/3.10.0.1 hpc/0.6.0.1 integer-gmp/0.5.1.0 old-locale/1.0.0.6 old-time/1.1.0.2 pretty/1.1.1.1 process/1.2.0.0 rts/1.0 template-haskell/2.9.0.0 terminfo/0.4.0.0 time/1.4.2 transformers/0.3.0.0 unix/2.7.0.1 xhtml/3000.2.1
+
+############################################
+# GHC 7.10.x
+
+7.10.1	Cabal/1.22.2.0 array/0.5.1.0 base/4.8.0.0 bin-package-db/0.0.0.0 binary/0.7.3.0 bytestring/0.10.6.0 containers/0.5.6.2 deepseq/1.4.1.1 directory/1.2.2.0 filepath/1.4.0.0 ghc/7.10.1* ghc-prim/0.4.0.0 haskeline/0.7.2.1 hoopl/3.10.0.2 hpc/0.6.0.2 integer-gmp/1.0.0.0 pretty/1.1.2.0 process/1.2.3.0 rts/1.0 template-haskell/2.10.0.0 terminfo/0.4.0.1 time/1.5.0.1 transformers/0.4.2.0 unix/2.7.1.0 xhtml/3000.2.1
+7.10.2	Cabal/1.22.4.0 array/0.5.1.0 base/4.8.1.0 bin-package-db/0.0.0.0 binary/0.7.5.0 bytestring/0.10.6.0 containers/0.5.6.2 deepseq/1.4.1.1 directory/1.2.2.0 filepath/1.4.0.0 ghc/7.10.2* ghc-prim/0.4.0.0 haskeline/0.7.2.1 hoopl/3.10.0.2 hpc/0.6.0.2 integer-gmp/1.0.0.0 pretty/1.1.2.0 process/1.2.3.0 rts/1.0 template-haskell/2.10.0.0 terminfo/0.4.0.1 time/1.5.0.1 transformers/0.4.2.0 unix/2.7.1.0 xhtml/3000.2.1
+7.10.3	Cabal/1.22.5.0 array/0.5.1.0 base/4.8.2.0 bin-package-db/0.0.0.0 binary/0.7.5.0 bytestring/0.10.6.0 containers/0.5.6.2 deepseq/1.4.1.1 directory/1.2.2.0 filepath/1.4.0.0 ghc/7.10.3* ghc-prim/0.4.0.0 haskeline/0.7.2.1 hoopl/3.10.0.2 hpc/0.6.0.2 integer-gmp/1.0.0.0 pretty/1.1.2.0 process/1.2.3.0 rts/1.0 template-haskell/2.10.0.0 terminfo/0.4.0.1 time/1.5.0.1 transformers/0.4.2.0 unix/2.7.1.0 xhtml/3000.2.1
+
+############################################
+# GHC 8.0.x
+
+8.0.1	Cabal/1.24.0.0 array/0.5.1.1 base/4.9.0.0 binary/0.8.3.0 bytestring/0.10.8.1 containers/0.5.7.1 deepseq/1.4.2.0 directory/1.2.6.2 filepath/1.4.1.0 ghc/8.0.1* ghc-boot/8.0.1 ghc-boot-th/8.0.1 ghc-prim/0.5.0.0 ghci/8.0.1 haskeline/0.7.2.3 hoopl/3.10.2.1 hpc/0.6.0.3 integer-gmp/1.0.0.1 pretty/1.1.3.3 process/1.4.2.0 rts/1.0 template-haskell/2.11.0.0 terminfo/0.4.0.2 time/1.6.0.1 transformers/0.5.2.0 unix/2.7.2.0 xhtml/3000.2.1
+8.0.2	Cabal/1.24.2.0 array/0.5.1.1 base/4.9.1.0 binary/0.8.3.0 bytestring/0.10.8.1 containers/0.5.7.1 deepseq/1.4.2.0 directory/1.3.0.0 filepath/1.4.1.1 ghc/8.0.2 ghc-boot/8.0.2 ghc-boot-th/8.0.2 ghc-prim/0.5.0.0 ghci/8.0.2 haskeline/0.7.3.0 hoopl/3.10.2.1 hpc/0.6.0.3 integer-gmp/1.0.0.1 pretty/1.1.3.3 process/1.4.3.0 rts/1.0 template-haskell/2.11.1.0 terminfo/0.4.0.2 time/1.6.0.1 transformers/0.5.2.0 unix/2.7.2.1 xhtml/3000.2.1
+
+############################################
+# GHC 8.2.x
+
+8.2.1   Cabal/2.0.0.2 array/0.5.2.0 base/4.10.0.0 binary/0.8.5.1 bytestring/0.10.8.2 containers/0.5.10.2 deepseq/1.4.3.0 directory/1.3.0.2 filepath/1.4.1.2 ghc/8.2.1* ghc-boot/8.2.1 ghc-boot-th/8.2.1 ghc-compact/0.1.0.0 ghc-prim/0.5.1.0 ghci/8.2.1 haskeline/0.7.4.0 hoopl/3.10.2.2 hpc/0.6.0.3 integer-gmp/1.0.1.0 pretty/1.1.3.3 process/1.6.1.0 rts/1.0 template-haskell/2.12.0.0 terminfo/0.4.1.0 time/1.8.0.2 transformers/0.5.2.0 unix/2.7.2.2 xhtml/3000.2.2
+8.2.2   Cabal/2.0.1.0 array/0.5.2.0 base/4.10.1.0 binary/0.8.5.1 bytestring/0.10.8.2 containers/0.5.10.2 deepseq/1.4.3.0 directory/1.3.0.2 filepath/1.4.1.2 ghc/8.2.2* ghc-boot/8.2.2 ghc-boot-th/8.2.2 ghc-compact/0.1.0.0 ghc-prim/0.5.1.0 ghci/8.2.2 haskeline/0.7.4.0 hoopl/3.10.2.2 hpc/0.6.0.3 integer-gmp/1.0.1.0 pretty/1.1.3.3 process/1.6.1.0 random/1.1 rts/1.0 template-haskell/2.12.0.0 terminfo/0.4.1.0 time/1.8.0.2 transformers/0.5.2.0 unix/2.7.2.2 xhtml/3000.2.2
+
+############################################
+# GHC 8.4.x
+
+8.4.1   Cabal/2.2.0.0 array/0.5.2.0 base/4.11.0.0 binary/0.8.5.1 bytestring/0.10.8.2 containers/0.5.11.0 deepseq/1.4.3.0 directory/1.3.1.5 filepath/1.4.2 ghc/8.4.1* ghc-boot/8.4.1 ghc-boot-th/8.4.1 ghc-compact/0.1.0.0 ghc-prim/0.5.2.0 ghci/8.4.1 haskeline/0.7.4.2 hpc/0.6.0.3 integer-gmp/1.0.1.0 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.3.0 rts/1.0 stm/2.4.5.0 template-haskell/2.13.0.0 terminfo/0.4.1.1 text/1.2.3.0 time/1.8.0.2 transformers/0.5.5.0 unix/2.7.2.2 xhtml/3000.2.2
+8.4.2   Cabal/2.2.0.1 array/0.5.2.0 base/4.11.1.0 binary/0.8.5.1 bytestring/0.10.8.2 containers/0.5.11.0 deepseq/1.4.3.0 directory/1.3.1.5 filepath/1.4.2 ghc/8.4.2* ghc-boot/8.4.2 ghc-boot-th/8.4.2 ghc-compact/0.1.0.0 ghc-prim/0.5.2.0 ghci/8.4.2 haskeline/0.7.4.2 hpc/0.6.0.3 integer-gmp/1.0.2.0 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.3.0 random/1.1 rts/1.0 template-haskell/2.13.0.0 terminfo/0.4.1.1 text/1.2.3.0 time/1.8.0.2 transformers/0.5.5.0 unix/2.7.2.2 xhtml/3000.2.2.1 stm/2.4.5.0
+8.4.3   Cabal/2.2.0.1 array/0.5.2.0 base/4.11.1.0 binary/0.8.5.1 bytestring/0.10.8.2 containers/0.5.11.0 deepseq/1.4.3.0 directory/1.3.1.5 filepath/1.4.2 ghc/8.4.3* ghc-boot/8.4.3 ghc-boot-th/8.4.3 ghc-compact/0.1.0.0 ghc-prim/0.5.2.0 ghci/8.4.3 haskeline/0.7.4.2 hpc/0.6.0.3 integer-gmp/1.0.2.0 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.3.0 rts/1.0 stm/2.4.5.0 template-haskell/2.13.0.0 terminfo/0.4.1.1 text/1.2.3.0 time/1.8.0.2 transformers/0.5.5.0 unix/2.7.2.2 xhtml/3000.2.2.1
+8.4.4	Cabal/2.2.0.1 array/0.5.2.0 base/4.11.1.0 binary/0.8.5.1 bytestring/0.10.8.2 containers/0.5.11.0 deepseq/1.4.3.0 directory/1.3.1.5 filepath/1.4.2 ghc/8.4.4* ghc-boot/8.4.4 ghc-boot-th/8.4.4 ghc-compact/0.1.0.0 ghc-prim/0.5.2.0 ghci/8.4.4 haskeline/0.7.4.2 hpc/0.6.0.3 integer-gmp/1.0.2.0 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.3.0 rts/1.0 stm/2.4.5.1 template-haskell/2.13.0.0 terminfo/0.4.1.1 text/1.2.3.1 time/1.8.0.2 transformers/0.5.5.0 unix/2.7.2.2 xhtml/3000.2.2.1
+
+############################################
+# GHC 8.6.x
+
+8.6.1   Cabal/2.4.0.1 array/0.5.2.0 base/4.12.0.0 binary/0.8.6.0 bytestring/0.10.8.2 containers/0.6.0.1 deepseq/1.4.4.0 directory/1.3.3.0 filepath/1.4.2.1 ghc/8.6.1* ghc-boot/8.6.1 ghc-boot-th/8.6.1 ghc-compact/0.1.0.0 ghc-heap/8.6.1 ghc-prim/0.5.3 ghci/8.6.1 haskeline/0.7.4.3 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.6.1 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.3.0 rts/1.0 stm/2.5.0.0 template-haskell/2.14.0.0 terminfo/0.4.1.2 text/1.2.3.1 time/1.8.0.2 transformers/0.5.5.0 unix/2.7.2.2 xhtml/3000.2.2.1
+8.6.2   Cabal/2.4.0.1 array/0.5.3.0 base/4.12.0.0 binary/0.8.6.0 bytestring/0.10.8.2 containers/0.6.0.1 deepseq/1.4.4.0 directory/1.3.3.0 filepath/1.4.2.1 ghc/8.6.2* ghc-boot/8.6.2 ghc-boot-th/8.6.2 ghc-compact/0.1.0.0 ghc-heap/8.6.2 ghc-prim/0.5.3 ghci/8.6.2 haskeline/0.7.4.3 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.6.1 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.3.0 rts/1.0 stm/2.5.0.0 template-haskell/2.14.0.0 terminfo/0.4.1.2 text/1.2.3.1 time/1.8.0.2 transformers/0.5.5.0 unix/2.7.2.2 xhtml/3000.2.2.1
+8.6.3   Cabal/2.4.0.1 array/0.5.3.0 base/4.12.0.0 binary/0.8.6.0 bytestring/0.10.8.2 containers/0.6.0.1 deepseq/1.4.4.0 directory/1.3.3.0 filepath/1.4.2.1 ghc/8.6.3 ghc-boot/8.6.3 ghc-boot-th/8.6.3 ghc-compact/0.1.0.0 ghc-heap/8.6.3 ghc-prim/0.5.3 ghci/8.6.3 haskeline/0.7.4.3 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.6.3 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.3.0 rts/1.0 stm/2.5.0.0 template-haskell/2.14.0.0 terminfo/0.4.1.2 text/1.2.3.1 time/1.8.0.2 transformers/0.5.5.0 unix/2.7.2.2 xhtml/3000.2.2.1
+8.6.4	Cabal/2.4.0.1 array/0.5.3.0 base/4.12.0.0 binary/0.8.6.0 bytestring/0.10.8.2 containers/0.6.0.1 deepseq/1.4.4.0 directory/1.3.3.0 filepath/1.4.2.1 ghc/8.6.4* ghc-boot/8.6.4 ghc-boot-th/8.6.4 ghc-compact/0.1.0.0 ghc-heap/8.6.4 ghc-prim/0.5.3 ghci/8.6.4 haskeline/0.7.4.3 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.6.3 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.5.0 rts/1.0 stm/2.5.0.0 template-haskell/2.14.0.0 terminfo/0.4.1.2 text/1.2.3.1 time/1.8.0.2 transformers/0.5.6.2 unix/2.7.2.2 xhtml/3000.2.2.1
+8.6.5	Cabal/2.4.0.1 array/0.5.3.0 base/4.12.0.0 binary/0.8.6.0 bytestring/0.10.8.2 containers/0.6.0.1 deepseq/1.4.4.0 directory/1.3.3.0 filepath/1.4.2.1 ghc/8.6.5* ghc-boot/8.6.5 ghc-boot-th/8.6.5 ghc-compact/0.1.0.0 ghc-heap/8.6.5 ghc-prim/0.5.3 ghci/8.6.5 haskeline/0.7.4.3 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.6.3 mtl/2.2.2 parsec/3.1.13.0 pretty/1.1.3.6 process/1.6.5.0 rts/1.0 stm/2.5.0.0 template-haskell/2.14.0.0 terminfo/0.4.1.2 text/1.2.3.1 time/1.8.0.2 transformers/0.5.6.2 unix/2.7.2.2 xhtml/3000.2.2.1
+
+############################################
+# GHC 8.8.x
+
+8.8.1   Cabal/3.0.0.0 array/0.5.4.0 base/4.13.0.0 binary/0.8.7.0 bytestring/0.10.9.0 containers/0.6.2.1 deepseq/1.4.4.0 directory/1.3.3.2 filepath/1.4.2.1 ghc/8.8.1* ghc-boot/8.8.1 ghc-boot-th/8.8.1 ghc-compact/0.1.0.0 ghc-heap/8.8.1 ghc-prim/0.5.3 ghci/8.8.1 haskeline/0.7.5.0 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.8.1 mtl/2.2.2 parsec/3.1.14.0 pretty/1.1.3.6 process/1.6.5.1 rts/1.0 stm/2.5.0.0 template-haskell/2.15.0.0 terminfo/0.4.1.4 text/1.2.4.0 time/1.9.3 transformers/0.5.6.2 unix/2.7.2.2 xhtml/3000.2.2.1
+
+############################################
+# GHC HEAD
+
+HEAD    Cabal/3.0.0.0 array/0.5.4.0 base/4.13.0.0 binary/0.8.7.0 bytestring/0.10.9.0 containers/0.6.2.1 deepseq/1.4.4.0 directory/1.3.3.2 filepath/1.4.2.1 ghc/8.9* ghc-boot/8.9* ghc-boot-th/8.9* ghc-compact/0.1.0.0 ghc-heap/8.9* ghc-prim/0.6.1 ghci/8.9* haskeline/0.7.5.0 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.9* mtl/2.2.2 parsec/3.1.14.0 pretty/1.1.3.6 process/1.6.5.1 stm/2.5.0.0 template-haskell/2.16.0.0 terminfo/0.4.1.4 text/1.2.3.1 time/1.9.3 transformers/0.5.6.2 unix/2.7.2.2 xhtml/3000.2.2.1

--- a/src/Stack2nix/Render.hs
+++ b/src/Stack2nix/Render.hs
@@ -40,58 +40,8 @@ import           Text.PrettyPrint.HughesPJClass          (Doc, fcat, nest,
                                                           pPrint, punctuate,
                                                           semi, space, text)
 
--- Boot packages (wired-in and non-wired-in).
--- These are set to `null` in the generated nix package set.
--- The wired-in packages follow
---    * https://github.com/commercialhaskell/stack/blob/d8e942ea69eb189f67a045f0c595612034dbb75d/src/Stack/Constants.hs#L102
---    * https://downloads.haskell.org/~ghc/7.10.1/docs/html/libraries/ghc/src/Module.html#integerPackageKey
--- For recent GHC releases:
---    * https://github.com/ghc/ghc/blob/ghc-8.2.2-release/compiler/basicTypes/Module.hs#L1073
---    * https://github.com/ghc/ghc/blob/ghc-8.4.4-release/compiler/basicTypes/Module.hs#L1078
---    * https://github.com/ghc/ghc/blob/ghc-8.6.4-release/compiler/basicTypes/Module.hs#L1066 (got rid of "dph-seq" and "dph-par")
---    * https://github.com/ghc/ghc/blob/334dd6da47326f47b/compiler/basicTypes/Module.hs#L1088 (in-progress 8.8)
--- TODO: This should probably be dependent on the GHC version used.
---       A split into wired-in and not-wired-in packages may also be advisable.
-basePackages :: Set String
-basePackages = Set.fromList
-  [ "array"
-  , "base"
-  -- bin-package-db is in GHC 7.10's boot libraries
-  , "bin-package-db"
-  , "binary"
-  , "bytestring"
-  , "Cabal"
-  , "containers"
-  , "deepseq"
-  , "directory"
-  , "dph-par" -- for GHC < 8.6
-  , "dph-seq" -- for GHC < 8.6
-  , "filepath"
-  , "ghc"
-  , "ghc-boot"
-  , "ghc-boot-th"
-  , "ghc-prim"
-  , "ghci"
-  , "haskeline"
-  , "hoopl"
-  , "hpc"
-  , "integer-gmp" -- for GHC < 8.8
-  , "integer-simple" -- for GHC < 8.8
-  , "integer-wired-in" -- for GHC >= 8.8, see https://gitlab.haskell.org/ghc/ghc/commit/fc2ff6dd7496a33bf68165b28f37f40b7d647418
-  , "interactive"
-  , "pretty"
-  , "process"
-  , "rts"
-  , "template-haskell"
-  , "terminfo"
-  , "time"
-  , "transformers"
-  , "unix"
-  , "xhtml"
-  ]
-
-render :: [Either Doc Derivation] -> Args -> [String] -> String -> IO ()
-render results args locals ghcnixversion = do
+render :: [Either Doc Derivation] -> Args -> [String] -> String -> Set String -> IO ()
+render results args locals ghcnixversion basePackages = do
    let docs = lefts results
    when (length docs > 0) $ do
      hPutStrLn stderr $ show docs

--- a/stack2nix.cabal
+++ b/stack2nix.cabal
@@ -11,6 +11,7 @@ build-type:          Simple
 extra-source-files:
   README.md
   ChangeLog.md
+  pkg_versions.txt
 cabal-version:       >= 1.10
 
 source-repository head
@@ -38,6 +39,7 @@ library
                      , regex-pcre >= 0.94.4 && < 0.95
                      , SafeSemaphore >= 0.10.1 && < 0.11
                      , stack >= 1.9
+                     , template-haskell
                      , temporary >= 1.2.0.4 && < 1.4
                      , text >= 1.2.2.1 && < 1.3
                      , time


### PR DESCRIPTION
See #84, #167.

Using https://github.com/bgamari/ghc-utils/tree/master/library-versions for it,
as a lookup Map compiled into the binary using TH.