### PR TITLE
change Cabal2nix.hs to allow for AArch64

### DIFF
--- a/src/Stack2nix/External/Cabal2nix.hs
+++ b/src/Stack2nix/External/Cabal2nix.hs
@@ -52,4 +52,5 @@ fromCabalPlatform :: Platform -> String
 fromCabalPlatform (Platform I386 Linux)   = "i686-linux"
 fromCabalPlatform (Platform X86_64 Linux) = "x86_64-linux"
 fromCabalPlatform (Platform X86_64 OSX)   = "x86_64-darwin"
+fromCabalPlatform (Platform AArch64 Linux)= "aarch64-linux"
 fromCabalPlatform p                       = error ("fromCabalPlatform: invalid Nix platform" ++ show p)


### PR DESCRIPTION
This little change stops stack2nix from needlessly erroring out on AArch64. Linux on AArch64 is an officially supported platform for Nix.